### PR TITLE
Port custom wait dialog to wx.ProgressDialog

### DIFF
--- a/eos/db/__init__.py
+++ b/eos/db/__init__.py
@@ -75,7 +75,7 @@ from eos.db.saveddata.queries import getUser, getCharacter, getFit, getFitsWithS
                                      getFitList, getFleetList, getFleet, save, remove, commit, add, \
                                      getCharactersForUser, getMiscData, getSquadsIDsWithFitID, getWing, \
                                      getSquad, getBoosterFits, getProjectedFits, getTargetResistsList, getTargetResists,\
-                                     clearPrices
+                                     clearPrices, countAllFits
 
 #If using in memory saveddata, you'll want to reflect it so the data structure is good.
 if config.saveddata_connectionstring == "sqlite:///:memory:":

--- a/eos/db/saveddata/queries.py
+++ b/eos/db/saveddata/queries.py
@@ -267,6 +267,11 @@ def getBoosterFits(ownerID=None, where=None, eager=None):
         fits = saveddata_session.query(Fit).options(*eager).filter(filter).all()
     return fits
 
+def countAllFits():
+    with sd_lock:
+        count = saveddata_session.query(Fit).count()
+    return count
+
 def countFitsWithShip(shipID, ownerID=None, where=None, eager=None):
     """
     Get all the fits using a certain ship.

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -568,7 +568,7 @@ class MainFrame(wx.Frame):
         overwrites cached message and updates dialog
         """
         if info == -1:
-            self.progressDialog.Destroy()
+            self.progressDialog.Hide()
         elif info != self.progressDialog.message and info is not None:
             self.progressDialog.message = info
             self.progressDialog.Pulse(info)
@@ -610,9 +610,8 @@ class MainFrame(wx.Frame):
             self.progressDialog.ShowModal()
 
     def backupCallback(self, info):
-        #print info
         if info == -1:
-            self.progressDialog.Destroy()
+            self.progressDialog.Hide()
         else:
             self.progressDialog.Update(info)
 
@@ -670,9 +669,8 @@ class MainFrame(wx.Frame):
 
         max = sFit.countAllFits()
         path = settings.getPath()
-        print max
         self.progressDialog = wx.ProgressDialog("Backup fits",
-                            "Generating HTML file at:\n%s"%path,
+                            "Generating HTML file at: %s"%path,
                             maximum=max, parent=self,
                             style=wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME)
 

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -330,57 +330,16 @@ class MainFrame(wx.Frame):
         dlg.ShowModal()
         dlg.Destroy()
 
-    def showImportDialog(self, event):
-        fits = []
-        sFit = service.Fit.getInstance()
-        dlg=wx.FileDialog(
-            self,
-            "Open One Or More Fitting Files",
-            wildcard = "EVE XML fitting files (*.xml)|*.xml|" \
-                       "EFT text fitting files (*.cfg)|*.cfg|" \
-                       "All Files (*)|*",
-            style = wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_MULTIPLE)
-        if (dlg.ShowModal() == wx.ID_OK):
-
-            self.progressDialog = wx.ProgressDialog("Importing fits", " "*100, parent=self,
-                              style = wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME)
-            self.progressDialog.message = None
-            sFit.importFitsThreaded(dlg.GetPaths(), self.importCallback)
-            self.progressDialog.ShowModal()
-            dlg.Destroy()
-
-    def importCallback(self, info):
-        if info == -1:
-            self.progressDialog.Destroy()
-        elif info != self.progressDialog.message and info is not None:
-            self.progressDialog.message = info
-            self.progressDialog.Pulse(info)
-        else:
-            self.progressDialog.Pulse()
-
-        # @todo: implement saveImportedFits where needed, modify _openAfterImport
-        #sFit = service.Fit.getInstance()
-        #IDs = sFit.saveImportedFits(fits)
-        #self._openAfterImport(len(fits), IDs)
-
-    def _openAfterImport(self, importCount, fitIDs):
-        if importCount == 1:
-            wx.PostEvent(self, FitSelected(fitID=fitIDs[0]))
-
-        self.shipBrowser.RefreshContent()
-
     def showExportDialog(self, event):
-        dlg=wx.FileDialog(
-            self,
-            "Save Fitting As...",
-            wildcard = "EVE XML fitting files (*.xml)|*.xml",
-            style = wx.FD_SAVE)
-        if (dlg.ShowModal() == wx.ID_OK):
+        """ Export active fit """
+        dlg = wx.FileDialog(self, "Save Fitting As...",
+                            wildcard = "EVE XML fitting files (*.xml)|*.xml",
+                            style = wx.FD_SAVE)
+        if dlg.ShowModal() == wx.ID_OK:
             sFit = service.Fit.getInstance()
             format = dlg.GetFilterIndex()
-            output = ""
             path = dlg.GetPath()
-            if (format == 0):
+            if format == 0:
                 output = sFit.exportXml(self.getActiveFit())
                 if '.' not in os.path.basename(path):
                     path += ".xml"
@@ -420,7 +379,7 @@ class MainFrame(wx.Frame):
         # Target Resists editor
         self.Bind(wx.EVT_MENU, self.showTargetResistsEditor, id=menuBar.targetResistsEditorId)
         # Import dialog
-        self.Bind(wx.EVT_MENU, self.showImportDialog, id=wx.ID_OPEN)
+        self.Bind(wx.EVT_MENU, self.fileImportDialog, id=wx.ID_OPEN)
         # Export dialog
         self.Bind(wx.EVT_MENU, self.showExportDialog, id=wx.ID_SAVEAS)
         # Import from Clipboard
@@ -565,11 +524,9 @@ class MainFrame(wx.Frame):
         sFit = service.Fit.getInstance()
         try:
             fits = sFit.importFitFromBuffer(fromClipboard(), self.getActiveFit())
-            IDs = sFit.saveImportedFits(fits)
-            self._openAfterImport(len(fits), IDs)
+            #self._openAfterImport(len(fits), IDs)
         except:
             pass
-
 
     def exportToClipboard(self, event):
         CopySelectDict = {CopySelectDialog.copyFormatEft: self.clipboardEft,
@@ -585,59 +542,103 @@ class MainFrame(wx.Frame):
             pass
         dlg.Destroy()
 
-    def updateProgressDialog(self,count):
-        if count == -1:
+    def fileImportDialog(self, event):
+        """Handles importing single/multiple EVE XML / EFT cfg fit files"""
+        sFit = service.Fit.getInstance()
+        dlg = wx.FileDialog(self, "Open One Or More Fitting Files",
+                    wildcard = "EVE XML fitting files (*.xml)|*.xml|" \
+                                "EFT text fitting files (*.cfg)|*.cfg|" \
+                                "All Files (*)|*",
+                    style = wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_MULTIPLE)
+        if (dlg.ShowModal() == wx.ID_OK):
+            self.progressDialog = wx.ProgressDialog(
+                            "Importing fits",
+                            " "*100, # set some arbitrary spacing to create wifth in window
+                            parent=self, style = wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME)
+            self.progressDialog.message = None
+            sFit.importFitsThreaded(dlg.GetPaths(), self.importCallback)
+            self.progressDialog.ShowModal()
+            dlg.Destroy()
+
+    def importCallback(self, info):
+        """
+        While importing fits from file, the logic calls back to this function to
+        update progress bar to show activity. If -1, closes dialog. If None,
+        simply Pulse()s progress. If there is a message to show new activity,
+        overwrites cached message and updates dialog
+        """
+        if info == -1:
             self.progressDialog.Destroy()
+        elif info != self.progressDialog.message and info is not None:
+            self.progressDialog.message = info
+            self.progressDialog.Pulse(info)
         else:
-            self.progressDialog.Update(count)
+            self.progressDialog.Pulse()
+
+        # @todo: modify _openAfterImport
+        #self._openAfterImport(len(fits), IDs)
+
+    def _openAfterImport(self, importCount, fitIDs):
+        if importCount == 1:
+            wx.PostEvent(self, FitSelected(fitID=fitIDs[0]))
+
+        self.shipBrowser.RefreshContent()
 
     def backupToXml(self, event):
-        sFit = service.Fit.getInstance()
-
+        """ Back up all fits to EVE XML file """
         defaultFile = "pyfa-fits-%s.xml"%strftime("%Y%m%d_%H%M%S", gmtime())
 
-        saveDialog = wx.FileDialog(
-            self,
-            "Save Backup As...",
-            wildcard = "EVE XML fitting file (*.xml)|*.xml",
-            style = wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
-            defaultFile=defaultFile)
+        saveDialog = wx.FileDialog(self, "Save Backup As...",
+                            wildcard = "EVE XML fitting file (*.xml)|*.xml",
+                            style = wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+                            defaultFile=defaultFile)
 
-        if (saveDialog.ShowModal() == wx.ID_OK):
+        if saveDialog.ShowModal() == wx.ID_OK:
             filePath = saveDialog.GetPath()
             if '.' not in os.path.basename(filePath):
                 filePath += ".xml"
 
+            sFit = service.Fit.getInstance()
             max = sFit.countAllFits()
+
             self.progressDialog = wx.ProgressDialog("Backup fits",
                               "Backing up %d fits to: %s"%(max, filePath),
-                              maximum = max, parent=self,
-                              style = wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME)
+                              maximum=max, parent=self,
+                              style=wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME)
 
-            sFit.backupFits(filePath, self.updateProgressDialog)
+            sFit.backupFits(filePath, self.backupCallback)
             self.progressDialog.ShowModal()
 
+    def backupCallback(self, info):
+        #print info
+        if info == -1:
+            self.progressDialog.Destroy()
+        else:
+            self.progressDialog.Update(info)
+
     def exportSkillsNeeded(self, event):
+        """ Exports skills needed for active fit and active character """
         sCharacter = service.Character.getInstance()
-        saveDialog = wx.FileDialog(
-            self,
-            "Export Skills Needed As...",
-            wildcard = "EVEMon skills training file (*.emp)|*.emp|" \
-                       "EVEMon skills training XML file (*.xml)|*.xml|" \
-                       "Text skills training file (*.txt)|*.txt",
-            style = wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT)
-        if (saveDialog.ShowModal() == wx.ID_OK):
+        saveDialog = wx.FileDialog(self, "Export Skills Needed As...",
+                    wildcard = "EVEMon skills training file (*.emp)|*.emp|" \
+                               "EVEMon skills training XML file (*.xml)|*.xml|" \
+                               "Text skills training file (*.txt)|*.txt",
+                    style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT)
+
+        if saveDialog.ShowModal() == wx.ID_OK:
             saveFmtInt = saveDialog.GetFilterIndex()
-            saveFmt = ""
+
             if saveFmtInt == 0:  # Per ordering of wildcards above
                 saveFmt = "emp"
             elif saveFmtInt == 1:
                 saveFmt = "xml"
             else:
                 saveFmt = "txt"
+
             filePath = saveDialog.GetPath()
             if '.' not in os.path.basename(filePath):
                 filePath += ".{0}".format(saveFmt)
+
             self.waitDialog = animUtils.WaitDialog(self)
             sCharacter.backupSkills(filePath, saveFmt, self.getActiveFit(), self.closeWaitDialog)
             self.waitDialog.ShowModal()
@@ -645,28 +646,38 @@ class MainFrame(wx.Frame):
         saveDialog.Destroy()
 
     def importCharacter(self, event):
-        sCharacter = service.Character.getInstance()
-        dlg=wx.FileDialog(
-            self,
-            "Open One Or More Character Files",
-            wildcard = "EVE CCP API XML character files (*.xml)|*.xml|" \
-                       "All Files (*)|*",
-            style = wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_MULTIPLE)
-        if (dlg.ShowModal() == wx.ID_OK):
-            self.waitDialog = animUtils.WaitDialog(self, title = "Importing Character")
+        """ Imports character XML file from EVE API """
+        dlg = wx.FileDialog(self, "Open One Or More Character Files",
+                        wildcard="EVE API XML character files (*.xml)|*.xml|" \
+                                   "All Files (*)|*",
+                        style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_MULTIPLE)
+
+        if dlg.ShowModal() == wx.ID_OK:
+            self.waitDialog = animUtils.WaitDialog(self, title="Importing Character")
+            sCharacter = service.Character.getInstance()
             sCharacter.importCharacter(dlg.GetPaths(), self.importCharacterCallback)
             dlg.Destroy()
             self.waitDialog.ShowModal()
 
-    def exportHtml(self, event):
-        from gui.utils.exportHtml import exportHtml
-        self.waitDialog = animUtils.WaitDialog(self)
-        exportHtml.getInstance().refreshFittingHtml(True, self.closeWaitDialog)
-        self.waitDialog.ShowModal()
-
     def importCharacterCallback(self):
         self.waitDialog.Destroy()
         wx.PostEvent(self, GE.CharListUpdated())
+
+    def exportHtml(self, event):
+        from gui.utils.exportHtml import exportHtml
+        sFit = service.Fit.getInstance()
+        settings = service.settings.HTMLExportSettings.getInstance()
+
+        max = sFit.countAllFits()
+        path = settings.getPath()
+        print max
+        self.progressDialog = wx.ProgressDialog("Backup fits",
+                            "Generating HTML file at:\n%s"%path,
+                            maximum=max, parent=self,
+                            style=wx.PD_APP_MODAL | wx.PD_ELAPSED_TIME)
+
+        exportHtml.getInstance().refreshFittingHtml(True, self.backupCallback)
+        self.progressDialog.ShowModal()
 
     def closeWaitDialog(self):
         self.waitDialog.Destroy()
@@ -679,7 +690,7 @@ class MainFrame(wx.Frame):
         else:
             self.graphFrame.SetFocus()
 
-    def openWXInspectTool(self,event):
+    def openWXInspectTool(self, event):
         from wx.lib.inspection import InspectionTool
         if not InspectionTool().initialized:
             InspectionTool().Init()

--- a/gui/utils/exportHtml.py
+++ b/gui/utils/exportHtml.py
@@ -7,7 +7,7 @@ class exportHtml():
     _instance = None
     @classmethod
     def getInstance(cls):
-        if cls._instance == None:
+        if cls._instance is None:
             cls._instance = exportHtml()
 
         return cls._instance
@@ -15,17 +15,17 @@ class exportHtml():
     def __init__(self):
         self.thread = exportHtmlThread()
 
-    def refreshFittingHtml(self, force = False, callback = False):
+    def refreshFittingHtml(self, force=False, callback=False):
         settings = service.settings.HTMLExportSettings.getInstance()
 
-        if (force or settings.getEnabled()):
+        if force or settings.getEnabled():
             self.thread.stop()
             self.thread = exportHtmlThread(callback)
             self.thread.start()
 
 class exportHtmlThread(threading.Thread):
 
-    def __init__(self, callback = False):
+    def __init__(self, callback=False):
         threading.Thread.__init__(self)
         self.callback = callback
         self.stopRunning = False
@@ -40,7 +40,7 @@ class exportHtmlThread(threading.Thread):
             return
 
         sMkt = service.Market.getInstance()
-        sFit    = service.Fit.getInstance()
+        sFit = service.Fit.getInstance()
         settings = service.settings.HTMLExportSettings.getInstance()
 
         timestamp = time.localtime(time.time())
@@ -135,6 +135,9 @@ class exportHtmlThread(threading.Thread):
         HTML += '  <ul data-role="listview" class="ui-listview-outer" data-inset="true" data-filter="true">\n'
         categoryList = list(sMkt.getShipRoot())
         categoryList.sort(key=lambda ship: ship.name)
+
+        count = 1
+
         for group in categoryList:
             # init market group string to give ships something to attach to
             HTMLgroup = ''
@@ -153,9 +156,17 @@ class exportHtmlThread(threading.Thread):
                         if self.stopRunning:
                             return
                         fit = fits[0]
-                        dnaFit = sFit.exportDna(fit[0])
-                        HTMLgroup += (
-                        '        <li><a data-dna="' + dnaFit + '" target="_blank">' + ship.name + ": " + fit[1] + '</a></li>\n')
+                        try:
+                            print fit[0]
+                            dnaFit = sFit.exportDna(fit[0])
+                            HTMLgroup += (
+                            '        <li><a data-dna="' + dnaFit + '" target="_blank">' + ship.name + ": " + fit[1] + '</a></li>\n')
+                        except:
+                            pass
+                        finally:
+                            count += 1
+                            if self.callback:
+                                wx.CallAfter(self.callback, count)
                     else:
                         # Ship group header
                         HTMLship = (
@@ -166,11 +177,18 @@ class exportHtmlThread(threading.Thread):
                         for fit in fits:
                             if self.stopRunning:
                                 return
-                            dnaFit = sFit.exportDna(fit[0])
-                            HTMLship += '          <li><a data-dna="' + dnaFit + '" target="_blank">' + fit[1] + '</a></li>\n'
-
+                            try:
+                                dnaFit = sFit.exportDna(fit[0])
+                                HTMLship += '          <li><a data-dna="' + dnaFit + '" target="_blank">' + fit[1] + '</a></li>\n'
+                            except:
+                                continue
+                            finally:
+                                count += 1
+                                if self.callback:
+                                    wx.CallAfter(self.callback, count)
                         HTMLgroup += HTMLship + ('          </ul>\n'
                                                  '        </li>\n')
+
             if groupFits > 0:
                 # Market group header
                 HTML += (
@@ -197,5 +215,5 @@ class exportHtmlThread(threading.Thread):
             pass
 
         if self.callback:
-            wx.CallAfter(self.callback)
+            wx.CallAfter(self.callback, -1)
 

--- a/gui/utils/exportHtml.py
+++ b/gui/utils/exportHtml.py
@@ -157,7 +157,6 @@ class exportHtmlThread(threading.Thread):
                             return
                         fit = fits[0]
                         try:
-                            print fit[0]
                             dnaFit = sFit.exportDna(fit[0])
                             HTMLgroup += (
                             '        <li><a data-dna="' + dnaFit + '" target="_blank">' + ship.name + ": " + fit[1] + '</a></li>\n')

--- a/service/fit.py
+++ b/service/fit.py
@@ -47,12 +47,11 @@ class FitBackupThread(threading.Thread):
         path = self.path
         sFit = Fit.getInstance()
         allFits = map(lambda x: x[0], sFit.getAllFits())
-        backedUpFits = sFit.exportXml(*allFits)
+        backedUpFits = sFit.exportXml(self.callback, *allFits)
         backupFile = open(path, "w", encoding="utf-8")
         backupFile.write(backedUpFits)
         backupFile.close()
-        wx.CallAfter(self.callback)
-
+        wx.CallAfter(self.callback, -1)
 
 class FitImportThread(threading.Thread):
     def __init__(self, paths, callback):
@@ -126,6 +125,9 @@ class Fit(object):
             names.append((fit.ID, fit.name, fit.shipID))
 
         return names
+
+    def countAllFits(self):
+        return eos.db.countAllFits()
 
     def countFitsWithShip(self, shipID):
         count = eos.db.countFitsWithShip(shipID)
@@ -758,9 +760,9 @@ class Fit(object):
         fit = eos.db.getFit(fitID)
         return Port.exportDna(fit)
 
-    def exportXml(self, *fitIDs):
+    def exportXml(self, callback = None, *fitIDs):
         fits = map(lambda fitID: eos.db.getFit(fitID), fitIDs)
-        return Port.exportXml(*fits)
+        return Port.exportXml(callback, *fits)
 
     def backupFits(self, path, callback):
         thread = FitBackupThread(path, callback)

--- a/service/port.py
+++ b/service/port.py
@@ -23,6 +23,7 @@ import json
 
 from eos.types import State, Slot, Module, Cargo, Fit, Ship, Drone, Implant, Booster
 import service
+import wx
 
 try:
     from collections import OrderedDict
@@ -503,11 +504,11 @@ class Port(object):
         return dna + "::"
 
     @classmethod
-    def exportXml(cls, *fits):
+    def exportXml(cls, callback=None, *fits):
         doc = xml.dom.minidom.Document()
         fittings = doc.createElement("fittings")
         doc.appendChild(fittings)
-        for fit in fits:
+        for i, fit in enumerate(fits):
             try:
                 fitting = doc.createElement("fitting")
                 fitting.setAttribute("name", fit.name)
@@ -571,5 +572,8 @@ class Port(object):
             except:
                 print "Failed on fitID: %d"%fit.ID
                 continue
+            finally:
+                if callback:
+                    wx.CallAfter(callback, i)
 
         return doc.toprettyxml()

--- a/service/port.py
+++ b/service/port.py
@@ -365,7 +365,6 @@ class Port(object):
         fits = []
 
         for i, fitting in enumerate(fittings):
-            print "fitting"
             f = Fit()
             f.name = fitting.getAttribute("name")
             # <localized hint="Maelstrom">Maelstrom</localized>


### PR DESCRIPTION
I never liked the "in progress" animation for pyfa. It doesn't give you any information, and just doesn't look great. wxPython comes with a handy wx.ProgressDialog that can replace it.

Before (fit backup/import):
![processing](https://cloud.githubusercontent.com/assets/3904767/5482808/206931ee-8635-11e4-8099-b4433c375caf.png)

After (backup/HTML export):
![progress](https://cloud.githubusercontent.com/assets/3904767/5482822/605b3b1c-8635-11e4-9484-1333a43fc82b.png)

After (importing):
![processing2](https://cloud.githubusercontent.com/assets/3904767/5483013/f1164b3a-8638-11e4-90ba-8d25e122178f.png)

waitDialog is still scattered around - most predominately while opening fits from previous pyfa session, but also when importing character and exporting skills needed (however these functions don't really take any time to do, so the wait dialog disappears so quickly). I am probably going to leave those in for now.

Need to test a bit more on Linux and OS X - from what I've tried it works great with importing multiple files and export as well, just need to thoroughly test.

