### PR TITLE
Make tab tooltips optional

### DIFF
--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -56,7 +56,6 @@ class PFGeneralPref ( PreferenceView):
         self.cbShowTooltip = wx.CheckBox( panel, wx.ID_ANY, u"Show tab tooltips", wx.DefaultPosition, wx.DefaultSize, 0 )
         mainSizer.Add( self.cbShowTooltip, 0, wx.ALL|wx.EXPAND, 5 )
 
-
         defCharSizer = wx.BoxSizer( wx.HORIZONTAL )
 
         self.sFit = service.Fit.getInstance()
@@ -69,7 +68,7 @@ class PFGeneralPref ( PreferenceView):
         self.cbRackLabels.SetValue(self.sFit.serviceFittingOptions["rackLabels"] or False)
         self.cbCompactSkills.SetValue(self.sFit.serviceFittingOptions["compactSkills"] or False)
         self.cbReopenFits.SetValue(self.openFitsSettings["enabled"])
-	self.cbShowTooltip.SetValue(self.sFit.serviceFittingOptions["showTooltip"] or False)
+        self.cbShowTooltip.SetValue(self.sFit.serviceFittingOptions["showTooltip"] or False)
 
         self.cbGlobalChar.Bind(wx.EVT_CHECKBOX, self.OnCBGlobalCharStateChange)
         self.cbGlobalDmgPattern.Bind(wx.EVT_CHECKBOX, self.OnCBGlobalDmgPatternStateChange)
@@ -79,7 +78,7 @@ class PFGeneralPref ( PreferenceView):
         self.cbRackLabels.Bind(wx.EVT_CHECKBOX, self.onCBGlobalRackLabels)
         self.cbCompactSkills.Bind(wx.EVT_CHECKBOX, self.onCBCompactSkills)
         self.cbReopenFits.Bind(wx.EVT_CHECKBOX, self.onCBReopenFits)
-	self.cbShowTooltip.Bind(wx.EVT_CHECKBOX, self.onCBShowTooltip)
+        self.cbShowTooltip.Bind(wx.EVT_CHECKBOX, self.onCBShowTooltip)
 
         self.cbRackLabels.Enable(self.sFit.serviceFittingOptions["rackSlots"] or False)
 

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -53,6 +53,10 @@ class PFGeneralPref ( PreferenceView):
         labelSizer.Add( self.cbRackLabels, 0, wx.ALL|wx.EXPAND, 5 )
         mainSizer.Add( labelSizer, 0, wx.LEFT|wx.EXPAND, 30 )
 
+        self.cbShowTooltip = wx.CheckBox( panel, wx.ID_ANY, u"Show tab tooltips", wx.DefaultPosition, wx.DefaultSize, 0 )
+        mainSizer.Add( self.cbShowTooltip, 0, wx.ALL|wx.EXPAND, 5 )
+
+
         defCharSizer = wx.BoxSizer( wx.HORIZONTAL )
 
         self.sFit = service.Fit.getInstance()
@@ -65,6 +69,7 @@ class PFGeneralPref ( PreferenceView):
         self.cbRackLabels.SetValue(self.sFit.serviceFittingOptions["rackLabels"] or False)
         self.cbCompactSkills.SetValue(self.sFit.serviceFittingOptions["compactSkills"] or False)
         self.cbReopenFits.SetValue(self.openFitsSettings["enabled"])
+	self.cbShowTooltip.SetValue(self.sFit.serviceFittingOptions["showTooltip"] or False)
 
         self.cbGlobalChar.Bind(wx.EVT_CHECKBOX, self.OnCBGlobalCharStateChange)
         self.cbGlobalDmgPattern.Bind(wx.EVT_CHECKBOX, self.OnCBGlobalDmgPatternStateChange)
@@ -74,6 +79,7 @@ class PFGeneralPref ( PreferenceView):
         self.cbRackLabels.Bind(wx.EVT_CHECKBOX, self.onCBGlobalRackLabels)
         self.cbCompactSkills.Bind(wx.EVT_CHECKBOX, self.onCBCompactSkills)
         self.cbReopenFits.Bind(wx.EVT_CHECKBOX, self.onCBReopenFits)
+	self.cbShowTooltip.Bind(wx.EVT_CHECKBOX, self.onCBShowTooltip)
 
         self.cbRackLabels.Enable(self.sFit.serviceFittingOptions["rackSlots"] or False)
 
@@ -126,6 +132,9 @@ class PFGeneralPref ( PreferenceView):
 
     def onCBReopenFits(self, event):
         self.openFitsSettings["enabled"] = self.cbReopenFits.GetValue()
+
+    def onCBShowTooltip(self, event):
+        self.sFit.serviceFittingOptions["showTooltip"] = self.cbShowTooltip.GetValue()
 
     def getImage(self):
         return bitmapLoader.getBitmap("prefs_settings", "icons")

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -166,8 +166,7 @@ class FittingView(d.Display):
                     if self.DEFAULT_COLS[col] == "Miscellanea":
                         tooltip = self.activeColumns[col].getToolTip(mod)
                         if tooltip is not None:
-                            #self.SetToolTipString(tooltip)
-                            self.SetToolTip(None)
+                            self.SetToolTipString(tooltip)
                         else:
                             self.SetToolTip(None)
                     else:

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -166,7 +166,8 @@ class FittingView(d.Display):
                     if self.DEFAULT_COLS[col] == "Miscellanea":
                         tooltip = self.activeColumns[col].getToolTip(mod)
                         if tooltip is not None:
-                            self.SetToolTipString(tooltip)
+                            #self.SetToolTipString(tooltip)
+                            self.SetToolTip(None)
                         else:
                             self.SetToolTip(None)
                     else:

--- a/gui/chromeTabs.py
+++ b/gui/chromeTabs.py
@@ -24,6 +24,8 @@ import gui.utils.drawUtils as drawUtils
 from gui import bitmapLoader
 import gui.utils.fonts as fonts
 
+import service
+
 _PageChanging, EVT_NOTEBOOK_PAGE_CHANGING = wx.lib.newevent.NewEvent()
 _PageChanged, EVT_NOTEBOOK_PAGE_CHANGED = wx.lib.newevent.NewEvent()
 _PageAdding, EVT_NOTEBOOK_PAGE_ADDING = wx.lib.newevent.NewEvent()
@@ -677,6 +679,7 @@ class PFTabsContainer(wx.Panel):
         self.containerHeight = height
         self.startDrag = False
         self.dragging = False
+        self.sFit = service.Fit.getInstance()
 
         self.inclination = 7
         if canAdd:
@@ -1010,6 +1013,9 @@ class PFTabsContainer(wx.Panel):
         Checks to see if we have a tab preview and sets up the timer for it
         to display
         """
+        if not self.sFit.serviceFittingOptions["showTooltip"] or False:
+            return
+
         if self.previewTimer:
             if self.previewTimer.IsRunning():
                 if self.previewWnd:

--- a/service/fit.py
+++ b/service/fit.py
@@ -96,7 +96,8 @@ class Fit(object):
             "colorFitBySlot": False,
             "rackSlots": True,
             "rackLabels": True,
-            "compactSkills": True}
+            "compactSkills": True,
+	    "showTooltip": True}
 
         self.serviceFittingOptions = SettingsProvider.getInstance().getSettings(
             "pyfaServiceFittingOptions", serviceFittingDefaultOptions)

--- a/service/fit.py
+++ b/service/fit.py
@@ -97,7 +97,7 @@ class Fit(object):
             "rackSlots": True,
             "rackLabels": True,
             "compactSkills": True,
-	    "showTooltip": True}
+            "showTooltip": True}
 
         self.serviceFittingOptions = SettingsProvider.getInstance().getSettings(
             "pyfaServiceFittingOptions", serviceFittingDefaultOptions)


### PR DESCRIPTION
The current tooltips can be a bit irritating in some cases, eg. when using a tiling window manager which changes its layout when a tooltip appears. This branch fixes that for me by making the tooltips optional.