### PR TITLE
Fix for #261

### DIFF
--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -737,7 +737,7 @@ class Fit(object):
         capAdded = 0
         for mod in self.modules:
             if mod.state >= State.ACTIVE:
-                if mod.getModifiedItemAttr("capacitorNeed") != 0:
+                if mod.getModifiedItemAttr("capacitorNeed") != 0 and mod.getModifiedItemAttr("capacitorNeed") is not None:
                     cycleTime = mod.rawCycleTime or 0
                     reactivationTime = mod.getModifiedItemAttr("moduleReactivationDelay") or 0
                     fullCycleTime = cycleTime + reactivationTime

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -737,7 +737,7 @@ class Fit(object):
         capAdded = 0
         for mod in self.modules:
             if mod.state >= State.ACTIVE:
-                if mod.getModifiedItemAttr("capacitorNeed") != 0 and mod.getModifiedItemAttr("capacitorNeed") is not None:
+                if (mod.getModifiedItemAttr("capacitorNeed") or 0) != 0:
                     cycleTime = mod.rawCycleTime or 0
                     reactivationTime = mod.getModifiedItemAttr("moduleReactivationDelay") or 0
                     fullCycleTime = cycleTime + reactivationTime


### PR DESCRIPTION
This addresses #261. Launchers do not have a "capacitorNeed" attribute (whilst projectile weapon systems do), so getModifiedItemAttr will return None rather than 0 when checking for cap-affecting modules. Adding an explicit check for None fixes the issue with the fit presented in the report. 