### PR TITLE
Fix stagger

### DIFF
--- a/eos/capSim.py
+++ b/eos/capSim.py
@@ -82,17 +82,22 @@ class CapSimulator(object):
             if self.scale:
                 duration, capNeed = self.scale_activation(duration, capNeed)
 
-            if self.stagger:
-                duration = int(duration/amount)
-            else:
-                capNeed *= amount
-
-            period = lcm(period, duration)
-
             # set clipSize to infinite if reloads are disabled unless it's
             # a cap booster module.
             if not self.reload and capNeed > 0:
                 clipSize = 0
+
+            if self.stagger:
+                if clipSize == 0:
+                    duration = int(duration/amount)
+                else:
+                    stagger_amount = (duration*clipsize+10000)/amount
+                    for i in range(1, amount):
+                        heapq.heappush(self.state, [i*stagger_amount, duration, capNeed, 0, clipSize])
+            else:
+                capNeed *= amount
+
+            period = lcm(period, duration)
 
             # period optimization doesn't work when reloads are active.
             if clipSize:

--- a/eos/capSim.py
+++ b/eos/capSim.py
@@ -91,9 +91,11 @@ class CapSimulator(object):
                 if clipSize == 0:
                     duration = int(duration/amount)
                 else:
-                    stagger_amount = (duration*clipsize+10000)/amount
+                    stagger_amount = (duration*clipSize+10000)/(amount*clipSize)
                     for i in range(1, amount):
-                        heapq.heappush(self.state, [i*stagger_amount, duration, capNeed, 0, clipSize])
+                        heapq.heappush(self.state,
+                                       [i*stagger_amount, duration,
+                                        capNeed, 0, clipSize])
             else:
                 capNeed *= amount
 


### PR DESCRIPTION
Here's a possible fix for issue #211. I've tested it briefly, and it seems to make the capacitor estimation more sensible.

It changes the logic for staggering modules if they require ammo. Rather than simply dividing the cycle time by the number of modules (which doesn't account for the increased number of charges that can be used before reloading or the staggering of the reload times), it schedules each module separately, starting at different multiples of `stagger_amount`.

The `stagger_amount` I've chosen is a middle of the road approach. It spaces out the modules based mostly on cycle time but with reload time factored in as well. This works well for modules that spend a lot of their time reloading (like cap boosters with large charges). You'll get a decent distribution, without any of the modules waiting a long time to start running.

A more aggressive staggering could be calculated by changing line 94 to `stagger_amount = (duration*clipSize+10000)/amount`. This will stagger the modules over the full ammo cycle, to make sure that they will be reloading as far apart from one another as possible. This, however, may not match how the modules are actually used in practice. Certainly, it will give odd results for hybrid guns (if `factorReload` is true) because those often have a quite long time between reloads. Cap unstable fits where hybrid guns are much of the cap drain may get unrealistically long capacitor lifetimes shown, since only a few of the guns will be active early on, while the others are waiting to start up. For modules with only one charge, this will give the same result as the "middle of the road" computation I've implemented.

A more conservative staggering can be computed by changing line 94 to `stagger_amount = duration / amount`. This will result in all of the modules having overlapping reload periods though, which for cap boosters would not be optimal.