### PR TITLE
Support fits exported from jEveAssets

### DIFF
--- a/pyfa.py
+++ b/pyfa.py
@@ -78,6 +78,10 @@ if __name__ == "__main__":
         config.saveInRoot = True
     config.defPaths()
 
+    # Basic logging
+    import logging
+    logging.basicConfig()
+
     # Import everything
     import wx
     import os


### PR DESCRIPTION
Support importing of fits exported from jEveAssets by implementing support for loading utf-16 XML.

Such XML is generated by software like jEveAssets's owned ships->fitting
export tool.

Without such detection, pyfa will go and try to import those as DNA
fits, with all the ensuing hilarity, thus the DNA import debug code as
well.