### PR TITLE
Showing Resist Multiplier in Tooltip

### DIFF
--- a/gui/builtinStatsViews/resistancesViewFull.py
+++ b/gui/builtinStatsViews/resistancesViewFull.py
@@ -197,8 +197,9 @@ class ResistancesViewFull(StatsView):
             lbl = getattr(self, "labelResistance%sEhp" % tankType.capitalize())
             if ehp is not None:
                 total += ehp[tankType]
+                rrFactor = fit.ehp[tankType] / fit.hp[tankType]
                 lbl.SetLabel(formatAmount(ehp[tankType], 3, 0, 9))
-                lbl.SetToolTip(wx.ToolTip("%s: %d" % (tankType.capitalize(), ehp[tankType])))
+                lbl.SetToolTip(wx.ToolTip("%s: %d, x%.2f" % (tankType.capitalize(), ehp[tankType], rrFactor)))
             else:
                 lbl.SetLabel("0")
 

--- a/gui/builtinStatsViews/resistancesViewFull.py
+++ b/gui/builtinStatsViews/resistancesViewFull.py
@@ -199,7 +199,7 @@ class ResistancesViewFull(StatsView):
                 total += ehp[tankType]
                 rrFactor = fit.ehp[tankType] / fit.hp[tankType]
                 lbl.SetLabel(formatAmount(ehp[tankType], 3, 0, 9))
-                lbl.SetToolTip(wx.ToolTip("%s: %d, x%.2f" % (tankType.capitalize(), ehp[tankType], rrFactor)))
+                lbl.SetToolTip(wx.ToolTip("%s: %d\nResist Multiplier: x%.2f" % (tankType.capitalize(), ehp[tankType], rrFactor)))
             else:
                 lbl.SetLabel("0")
 


### PR DESCRIPTION
Implements #248 .

Calculate multiplier by diving EHP by HP and showing the result in a new line in the tooltip.