### PR TITLE
Context menu to swap modules for different variation

### DIFF
--- a/eos/effectHandlerHelpers.py
+++ b/eos/effectHandlerHelpers.py
@@ -159,6 +159,10 @@ class HandledModuleList(HandledList):
             dummy.position = index
             self[index] = dummy
 
+    def toModule(self, index, mod):
+        mod.position = index
+        self[index] = mod
+
     def freeSlot(self, slot):
         for i in range(len(self) -1, -1, -1):
             mod = self[i]

--- a/gui/builtinContextMenus/__init__.py
+++ b/gui/builtinContextMenus/__init__.py
@@ -19,4 +19,5 @@ __all__ = [
     "targetResists",
     "priceClear",
     "amount",
+    "metaSwap",
 ]

--- a/gui/builtinContextMenus/metaSwap.py
+++ b/gui/builtinContextMenus/metaSwap.py
@@ -6,12 +6,6 @@ import service
 import wx
 import gui.globalEvents as GE
 
-# TODO:
-# Handle multiple selection better
-# Icons?
-# Submenu for officer?
-# Officer/Deadspace sorting
-
 class MetaSwap(ContextMenu):
     def __init__(self):
         self.mainFrame = gui.mainFrame.MainFrame.getInstance()
@@ -46,10 +40,15 @@ class MetaSwap(ContextMenu):
         def get_metalevel(x):
             return x.attributes["metaLevel"].value
 
+        def get_metagroup(x):
+            return x.metaGroup.ID if x.metaGroup is not None else 0
+
         m = wx.Menu()
 
+        # Sort items by metalevel, and group within that metalevel
         items = list(self.variations)
         items.sort(key=get_metalevel)
+        items.sort(key=get_metagroup)
 
         group = None
         for item in items:
@@ -57,6 +56,7 @@ class MetaSwap(ContextMenu):
             if item.metaGroup is None:
                 thisgroup = "Tech I"
             else:
+                print item.metaGroup.ID
                 thisgroup = item.metaGroup.name
 
             if thisgroup != group:

--- a/gui/builtinContextMenus/metaSwap.py
+++ b/gui/builtinContextMenus/metaSwap.py
@@ -56,7 +56,6 @@ class MetaSwap(ContextMenu):
             if item.metaGroup is None:
                 thisgroup = "Tech I"
             else:
-                print item.metaGroup.ID
                 thisgroup = item.metaGroup.name
 
             if thisgroup != group:

--- a/gui/builtinContextMenus/metaSwap.py
+++ b/gui/builtinContextMenus/metaSwap.py
@@ -45,6 +45,13 @@ class MetaSwap(ContextMenu):
 
         m = wx.Menu()
 
+        # If on Windows we need to bind out events into the root menu, on other
+        # platforms they need to go to our sub menu
+        if "wxMSW" in wx.PlatformInfo:
+            bindmenu = rootMenu
+        else:
+            bindmenu = m
+
         # Sort items by metalevel, and group within that metalevel
         items = list(self.variations)
         items.sort(key=get_metalevel)
@@ -66,7 +73,7 @@ class MetaSwap(ContextMenu):
 
             id = wx.NewId()
             mitem = wx.MenuItem(rootMenu, id, item.name)
-            rootMenu.Bind(wx.EVT_MENU, self.handleModule, mitem)
+            bindmenu.Bind(wx.EVT_MENU, self.handleModule, mitem)
             self.moduleLookup[id] = item
             m.AppendItem(mitem)
         return m

--- a/gui/builtinContextMenus/metaSwap.py
+++ b/gui/builtinContextMenus/metaSwap.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from gui.contextMenu import ContextMenu
+from gui.itemStats import ItemStatsDialog
+import gui.mainFrame
+import service
+import wx
+
+class MetaSwap(ContextMenu):
+    def __init__(self):
+        self.mainFrame = gui.mainFrame.MainFrame.getInstance()
+
+    def display(self, srcContext, selection):
+
+        if self.mainFrame.getActiveFit() is None or srcContext not in ("fittingModule", "projectedModule"):
+            return False
+
+        self.module = selection[0]
+
+        return True
+
+    def getText(self, itmContext, selection):
+        return "Variations"
+
+    def getSubMenu(self, context, selection, rootMenu, i, pitem):
+        def get_metalevel(x):
+            return x.attributes["metaLevel"].value
+
+        m = wx.Menu()
+        mkt = service.Market.getInstance()
+        items = list(mkt.getVariationsByItems([selection[0].item]))
+        items.sort(key=get_metalevel)
+        group = None
+        for item in items:
+            # Apparently no metaGroup for the Tech I variant:
+            if item.metaGroup is None:
+                thisgroup = "Tech I"
+            else:
+                thisgroup = item.metaGroup.name
+
+            if thisgroup != group:
+                group = thisgroup
+                id = wx.NewId()
+                m.Append(id, u'─ %s ─' % group)
+                m.Enable(id, False)
+
+            id = wx.NewId()
+            name = item.name
+            m.AppendItem(wx.MenuItem(rootMenu, id, name))
+        return m
+
+MetaSwap.register()


### PR DESCRIPTION
In the true spirit of open source - if you want a feature write it yourself.

This PR adds a right-click context menu (for modules) that brings up a list of meta-variations for the selected item(s). Selecting an item changes those modules to the selected meta-variation.
If multiple items are selected, menu only shows up if the variation list would be the same.

Saves a lot of clicking to meta-up or down a module to fit within skills or power budget etc.

I had a good look at the existing code, but I'm sure there are some style or architectural things you'll want me to fix.

(edit by blitzmann) Screenshot of how it looks:

![untitled](https://cloud.githubusercontent.com/assets/3904767/9310081/99d1d238-44db-11e5-9c52-18324d71bec3.png)
