### PR TITLE
Fix for issue 347

### DIFF
--- a/eos/graph/fitDps.py
+++ b/eos/graph/fitDps.py
@@ -43,7 +43,8 @@ class FitDpsGraph(Graph):
                 if "ewTargetPaint" in mod.item.effects:
                     ew['signatureRadius'].append(1+(mod.getModifiedItemAttr("signatureRadiusBonus") / 100))
                 if "decreaseTargetSpeed" in mod.item.effects:
-                    ew['velocity'].append(1+(mod.getModifiedItemAttr("speedFactor") / 100))
+                    if distance <= mod.getModifiedItemAttr("maxRange"):
+                        ew['velocity'].append(1+(mod.getModifiedItemAttr("speedFactor") / 100))
 
         ew['signatureRadius'].sort(key=abssort)
         ew['velocity'].sort(key=abssort)


### PR DESCRIPTION
Added a check for webs when graphing, where the effect is only applied if the target is within the web range. This should address #347.

This seems to do the job, giving me what I expect on the graph view with multiple webs in heated/unheated states, but I'd appreciate someone running over possible edge cases to confirm it works properly.

Test fits were variants of the following, with the webs in online, offline and heated states on different fits, graphed with settings ```{ distance: '0-100', velocity: 1000, angle: 90, signature: 100 }```.

```
[Moa, 347-TEST]

[Empty Low slot]
[Empty Low slot]
[Empty Low slot]
[Empty Low slot]

Stasis Webifier II
Federation Navy Stasis Webifier
Tracking Computer II
Tracking Computer II
Tracking Computer II

250mm Railgun II, Caldari Navy Antimatter Charge M
250mm Railgun II, Caldari Navy Antimatter Charge M
250mm Railgun II, Caldari Navy Antimatter Charge M
250mm Railgun II, Caldari Navy Antimatter Charge M
250mm Railgun II, Caldari Navy Antimatter Charge M

[Empty Rig slot]
[Empty Rig slot]
[Empty Rig slot]
```