### PR TITLE
Add a simple usage note to projected view

### DIFF
--- a/gui/projectedView.py
+++ b/gui/projectedView.py
@@ -27,18 +27,18 @@ from gui.contextMenu import ContextMenu
 import eos.types
 
 class ProjectedViewDrop(wx.PyDropTarget):
-        def __init__(self, dropFn):
-            wx.PyDropTarget.__init__(self)
-            self.dropFn = dropFn
-            # this is really transferring an EVE itemID
-            self.dropData = wx.PyTextDataObject()
-            self.SetDataObject(self.dropData)
+   def __init__(self, dropFn):
+       wx.PyDropTarget.__init__(self)
+       self.dropFn = dropFn
+       # this is really transferring an EVE itemID
+       self.dropData = wx.PyTextDataObject()
+       self.SetDataObject(self.dropData)
 
-        def OnData(self, x, y, t):
-            if self.GetData():
-                data = self.dropData.GetText().split(':')
-                self.dropFn(x, y, data)
-            return t
+   def OnData(self, x, y, t):
+       if self.GetData():
+           data = self.dropData.GetText().split(':')
+           self.dropFn(x, y, data)
+       return t
 
 class ProjectedView(d.Display):
     DEFAULT_COLS = ["State",

--- a/gui/projectedView.py
+++ b/gui/projectedView.py
@@ -197,6 +197,11 @@ class ProjectedView(d.Display):
     def get(self, row):
         numMods = len(self.modules)
         numDrones = len(self.drones)
+        numFits = len(self.fits)
+
+        if (numMods + numDrones + numFits) == 0:
+            return None
+
         if row < numMods:
             stuff = self.modules[row]
         elif row - numMods < numDrones:

--- a/gui/projectedView.py
+++ b/gui/projectedView.py
@@ -26,6 +26,16 @@ from gui.builtinViewColumns.state import State
 from gui.contextMenu import ContextMenu
 import eos.types
 
+
+class DummyItem:
+    def __init__(self, txt):
+        self.name = txt
+        self.icon = None
+
+class DummyEntry:
+    def __init__(self, txt):
+        self.item = DummyItem(txt)
+
 class ProjectedViewDrop(wx.PyDropTarget):
    def __init__(self, dropFn):
        wx.PyDropTarget.__init__(self)
@@ -178,6 +188,10 @@ class ProjectedView(d.Display):
                 self.EnsureVisible(item)
 
             self.deselectItems()
+
+        if stuff == []:
+            stuff = [DummyEntry("Drag an item or fit, or use right-click menu for system effects")]
+
         self.update(stuff)
 
     def get(self, row):

--- a/gui/projectedView.py
+++ b/gui/projectedView.py
@@ -96,8 +96,6 @@ class ProjectedView(d.Display):
                 sFit.removeProjected(fitID, self.get(row))
                 wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fitID))
 
-        event.Skip()
-
     def handleDrag(self, type, fitID):
         #Those are drags coming from pyfa sources, NOT builtin wx drags
         if type == "fit":


### PR DESCRIPTION
Had a few people in corp not realise you could put a whole ship fitting in the 'Projected' view. Thought a basic usage hint might help.

![cropped_screenshot](https://cloud.githubusercontent.com/assets/997500/10459435/61f4511a-71c7-11e5-9488-51f21e8fd386.png)
