### PR TITLE
Fix for issue 300

### DIFF
--- a/eos/capSim.py
+++ b/eos/capSim.py
@@ -169,12 +169,12 @@ class CapSimulator(object):
 
             iterations += 1
 
+            t_last = t_now
+
             if cap < cap_lowest:
                 if cap < 0.0:
                     break
                 cap_lowest = cap
-
-            t_last = t_now
 
             # queue the next activation of this module
             t_now += duration


### PR DESCRIPTION
Modified capsim so that for non-capstable fits, the capacitor time will indicate the time at which the first module failed to activate due to insufficient capacitor rather than the time of the last successful activation.

Resolves #300