### PR TITLE
Added option for disabling capacitor simulation staggering for certain modules

### DIFF
--- a/eos/capSim.py
+++ b/eos/capSim.py
@@ -59,7 +59,7 @@ class CapSimulator(object):
         return duration, capNeed
 
     def init(self, modules):
-        """prepare modules. a list of (duration, capNeed, clipSize) tuples is
+        """prepare modules. a list of (duration, capNeed, clipSize, disableStagger) tuples is
          expected, with clipSize 0 if the module has infinite ammo.
             """
         self.modules = modules
@@ -72,7 +72,7 @@ class CapSimulator(object):
         disable_period = False
 
         # Loop over modules, clearing clipSize if applicable, and group modules based on attributes
-        for (duration, capNeed, clipSize) in self.modules:
+        for (duration, capNeed, clipSize, disableStagger) in self.modules:
             if self.scale:
                 duration, capNeed = self.scale_activation(duration, capNeed)
 
@@ -82,14 +82,14 @@ class CapSimulator(object):
                 clipSize = 0
 
             # Group modules based on their properties
-            if (duration, capNeed, clipSize) in mods:
-                mods[(duration, capNeed, clipSize)] += 1
+            if (duration, capNeed, clipSize, disableStagger) in mods:
+                mods[(duration, capNeed, clipSize, disableStagger)] += 1
             else:
-                mods[(duration, capNeed, clipSize)] = 1
+                mods[(duration, capNeed, clipSize, disableStagger)] = 1
 
         # Loop over grouped modules, configure staggering and push to the simulation state
-        for (duration, capNeed, clipSize), amount in mods.iteritems():
-            if self.stagger:
+        for (duration, capNeed, clipSize, disableStagger), amount in mods.iteritems():
+            if self.stagger and not disableStagger:
                 if clipSize == 0:
                     duration = int(duration/amount)
                 else:

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -25,7 +25,7 @@ from eos import capSim
 from copy import deepcopy
 from math import sqrt, log, asinh
 from eos.types import Drone, Cargo, Ship, Character, State, Slot, Module, Implant, Booster, Skill
-from eos.saveddata.module import State
+from eos.saveddata.module import State, Hardpoint
 from eos.saveddata.mode import Mode
 import eos.db
 import time
@@ -847,8 +847,8 @@ class Fit(object):
                         else:
                             capAdded -= capNeed
 
-                        # Does the RoF attribute exist? If so, this is a turret, don't stagger activations
-                        disableStagger = (mod.getModifiedItemAttr("speed") or 0) != 0
+                        # If this is a turret, don't stagger activations
+                        disableStagger = mod.hardpoint == Hardpoint.TURRET
 
                         drains.append((int(fullCycleTime), mod.getModifiedItemAttr("capacitorNeed") or 0, mod.numShots or 0, disableStagger))
 

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -847,10 +847,14 @@ class Fit(object):
                         else:
                             capAdded -= capNeed
 
-                        drains.append((int(fullCycleTime), mod.getModifiedItemAttr("capacitorNeed") or 0, mod.numShots or 0))
+                        # Does the RoF attribute exist? If so, this is a turret, don't stagger activations
+                        disableStagger = (mod.getModifiedItemAttr("speed") or 0) != 0
+
+                        drains.append((int(fullCycleTime), mod.getModifiedItemAttr("capacitorNeed") or 0, mod.numShots or 0, disableStagger))
 
         for fullCycleTime, capNeed, clipSize in self.iterDrains():
-            drains.append((int(fullCycleTime), capNeed, clipSize))
+            # Stagger incoming effects for cap simulation
+            drains.append((int(fullCycleTime), capNeed, clipSize, False))
             if capNeed > 0:
                 capUsed += capNeed / (fullCycleTime / 1000.0)
             else:


### PR DESCRIPTION
Playing with the cap simulator, I noticed that turrets of the same type stack and have staggering applied when running through the cap simulator. This is not realistic behaviour as most (all?) pilots will
have grouped their turrets in-game, meaning they will all activate simultaneously rather than activating individually, offset from each other.

This change introduces a 'disable stagger' field to the drain tuple that is passed through to the cap simulator, allowing us to disable staggering on certain modules. This will enable us to add GUI options in the future to allow users to choose whether to stagger certain modules (eg, cap boosters, neuts) or have them all fire simultaneously. Currently this defaults to False (existing behavior) for all modules except for turrets, which will now behave more like in-game turrets for cap simulation purposes.